### PR TITLE
Fix git committing author issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,11 @@ Changed
 * Extended CONTRIBUTING guidelines to include a notice for adding ``Rules`` and ``Preconditions`` (https://github.com/gabor-boros/hammurabi/pull/11)
 * Refactor package structure and extract preconditions to separate submodule (https://github.com/gabor-boros/hammurabi/pull/11)
 
+Fixed
+~~~~~
+
+* Remove faulty author of git committing (https://github.com/gabor-boros/hammurabi/pull/12)
+
 0.1.2_ - 2020-03-18
 --------------------
 

--- a/hammurabi/mixins.py
+++ b/hammurabi/mixins.py
@@ -97,9 +97,7 @@ class GitMixin:
 
         if config.repo and not config.settings.dry_run:
             logging.debug("Creating git commit for the changes")
-            config.repo.index.commit(
-                message, author="Hammurabi"
-            )  # pylint: disable=no-member
+            config.repo.index.commit(message)  # pylint: disable=no-member
 
     @staticmethod
     def push_changes():

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -121,9 +121,7 @@ def test_git_commit(mocked_config):
 
     git_mixin.git_commit(commit_message)
 
-    mocked_config.repo.index.commit.assert_called_once_with(
-        commit_message, author="Hammurabi"
-    )
+    mocked_config.repo.index.commit.assert_called_once_with(commit_message)
 
 
 @patch("hammurabi.mixins.config")


### PR DESCRIPTION
**Reason for the change**

Committing fails when author is set as string, also this does not give that much value.

**Description**

Fix git committing author issue.

**Checklist**

- [x] Unit tests created/updated
~- [ ] Documentation extended/updated~
~- [ ] Stubs created/updated~

**References**

N/A
