### PR TITLE
Target is set to optional but required

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Unreleased_
 Changed
 ~~~~~~~
 
+* Make sure ``SectionExists`` adds the section even if no target given (https://github.com/gabor-boros/hammurabi/pull/21)
 * Apply PEP-561 (https://github.com/gabor-boros/hammurabi/pull/19)
 
 0.2.0_ - 2020-03-23

--- a/hammurabi/rules/ini.py
+++ b/hammurabi/rules/ini.py
@@ -137,6 +137,10 @@ class SectionExists(SingleConfigFileRule):
 
         if not self.target or self.target not in sections:
             self.updater.add_section(self.section)
+            section = self.updater[self.section]
+
+            if list(self.updater.keys()).index(section) != 0:
+                section.add_before.space(self.space)
         else:
             target = self.updater[self.target]
 

--- a/hammurabi/rules/ini.py
+++ b/hammurabi/rules/ini.py
@@ -106,7 +106,7 @@ class SectionExists(SingleConfigFileRule):
         add_after: bool = True,
         **kwargs,
     ) -> None:
-        self.target = self.validate(target, required=True)
+        self.target = target
         self.options = options
         self.add_after = add_after
 
@@ -120,29 +120,24 @@ class SectionExists(SingleConfigFileRule):
         the given name, and optionally the specified options.
 
         In case options are set, the config options will be assigned to that config sections.
-        A ``LookupError`` exception will be raised if the target section can not be found.
+        If the target is not found or not provided, the section will be added without any
+        intentional positioning. It means that it may be added to the top, bottom or even to
+        the middle of the config file.
 
-        :raises: ``LookupError`` raised if no target can be found
         :return: Return the input path as an output
         :rtype: Path
         """
 
         sections = self.updater.sections()
 
-        if not sections:
-            logging.debug('adding section "%s"', self.section)
+        if self.updater.has_section(self.section):
+            return self.param
 
+        logging.debug('adding section "%s"', self.section)
+
+        if not self.target or self.target not in sections:
             self.updater.add_section(self.section)
-
-            for option, value in self.options:
-                self.updater[self.section][option] = value
-
-        if not self.updater.has_section(self.section):
-
-            if self.target not in sections:
-                raise LookupError(f'No matching section for "{self.target}"')
-
-            logging.debug('adding section "%s"', self.section)
+        else:
             target = self.updater[self.target]
 
             if self.add_after:
@@ -150,8 +145,8 @@ class SectionExists(SingleConfigFileRule):
             else:
                 target.add_before.section(self.section)
 
-            for option, value in self.options:
-                self.updater[self.section][option] = value
+        for option, value in self.options:
+            self.updater[self.section][option] = value
 
         with self.param.open("w") as file:
             self.updater.write(file)

--- a/tests/integration_tests/rules/test_ini.py
+++ b/tests/integration_tests/rules/test_ini.py
@@ -32,6 +32,28 @@ def test_section_exists(temporary_file):
 
 
 @pytest.mark.integration
+def test_section_exists_no_target(temporary_file):
+    expected_file = Path(temporary_file.name)
+    expected_file.write_text("[main]")
+
+    rule = SectionExists(
+        name="Ensure section exists",
+        path=expected_file,
+        section="test_section",
+        options=(("option_1", "some value"), ("option_2", True)),
+    )
+
+    rule.pre_task_hook()
+    rule.task()
+
+    assert (
+        expected_file.read_text()
+        == "[main]\n[test_section]\noption_1 = some value\noption_2 = True\n"
+    )
+    expected_file.unlink()
+
+
+@pytest.mark.integration
 def test_section_exists_keeping_comment(temporary_file):
     expected_file = Path(temporary_file.name)
     expected_file.write_text(";commenting some thing\n[main]")

--- a/tests/rules/test_ini.py
+++ b/tests/rules/test_ini.py
@@ -133,6 +133,8 @@ def test_section_exists_no_sections(mocked_updater_class):
     expected_target = Mock()
 
     mocked_updater = MagicMock()
+    mocked_updater.__getitem__.return_value = expected_section
+    mocked_updater.keys.return_value = {expected_section}
     mocked_updater.sections.return_value = []
     mocked_updater.has_section.return_value = False
 
@@ -163,6 +165,8 @@ def test_section_exists_no_target(mocked_updater_class):
     expected_target = Mock()
 
     mocked_updater = MagicMock()
+    mocked_updater.__getitem__.return_value = expected_section
+    mocked_updater.keys.return_value = {expected_section}
     mocked_updater.sections.return_value = [Mock(), Mock()]
     mocked_updater.has_section.return_value = False
 
@@ -192,6 +196,8 @@ def test_section_exists_missing_target(mocked_updater_class):
     expected_section = Mock()
 
     mocked_updater = MagicMock()
+    mocked_updater.__getitem__.return_value = expected_section
+    mocked_updater.keys.return_value = {expected_section}
     mocked_updater.sections.return_value = [Mock(), Mock()]
     mocked_updater.has_section.return_value = False
 

--- a/tests/rules/test_ini.py
+++ b/tests/rules/test_ini.py
@@ -134,7 +134,7 @@ def test_section_exists_no_sections(mocked_updater_class):
 
     mocked_updater = MagicMock()
     mocked_updater.sections.return_value = []
-    mocked_updater.has_section.return_value = True
+    mocked_updater.has_section.return_value = False
 
     mocked_updater_class.return_value = mocked_updater
 
@@ -175,11 +175,39 @@ def test_section_exists_no_target(mocked_updater_class):
         target=expected_target,
     )
 
-    with pytest.raises(LookupError):
-        rule.task()
+    rule.task()
 
     mocked_updater.sections.assert_called_once_with()
     mocked_updater.has_section.assert_called_once_with(expected_section)
+    mocked_updater.add_section.assert_called_once_with(expected_section)
+
+
+@patch("hammurabi.rules.ini.ConfigUpdater")
+def test_section_exists_missing_target(mocked_updater_class):
+    mock_file = Mock()
+    expected_path = Mock()
+    expected_path.open.return_value.__enter__ = Mock(return_value=mock_file)
+    expected_path.open.return_value.__exit__ = Mock()
+
+    expected_section = Mock()
+
+    mocked_updater = MagicMock()
+    mocked_updater.sections.return_value = [Mock(), Mock()]
+    mocked_updater.has_section.return_value = False
+
+    mocked_updater_class.return_value = mocked_updater
+
+    rule = SectionExists(
+        name="Section exists rule",
+        path=expected_path,
+        section=expected_section,
+    )
+
+    rule.task()
+
+    mocked_updater.sections.assert_called_once_with()
+    mocked_updater.has_section.assert_called_once_with(expected_section)
+    mocked_updater.add_section.assert_called_once_with(expected_section)
 
 
 @patch("hammurabi.rules.ini.ConfigUpdater")

--- a/tests/rules/test_ini.py
+++ b/tests/rules/test_ini.py
@@ -198,9 +198,7 @@ def test_section_exists_missing_target(mocked_updater_class):
     mocked_updater_class.return_value = mocked_updater
 
     rule = SectionExists(
-        name="Section exists rule",
-        path=expected_path,
-        section=expected_section,
+        name="Section exists rule", path=expected_path, section=expected_section
     )
 
     rule.task()


### PR DESCRIPTION
**Reason for the change**

Parameter `target` must be set for Section exists even it is an optional parameter. This is the result of a started, but forgotten refactoring.

**Description**

In case of no target given or found for a section, create it instead of raising an exception.

**Code examples**

```python
from pathlib import Path
from hammurabi import Law, Pillar, SectionExists

example_law = Law(
    name="Name of the law",
    description="Well detailed description what this law does.",
    rules=(
        SectionExists(
            name="Ensure section exists",
            path=Path("./config.ini"),
            section="polling",
            options=(
                ("interval", "2s"),
                ("abort_on_error", True),
            ),
        ),
    )
)

pillar = Pillar()
pillar.register(example_law)
```

**Checklist**

- [x] Unit tests created/updated
- [x] Documentation extended/updated

**References**

N/A
