### PR TITLE
Bug hunting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Changed
 
 * Make sure children and pipe can be set at the same time
 * ``SectionRenamed`` not raises error if old section name is not represented but the new one
+* ``OptionRenamed`` not raises error if old option name is not represented but the new one
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,11 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 Unreleased
 ----------
 
+Changed
+~~~~~~~
+
+* Make sure children and pipe can be set at the same time
+
 0.3.1_ - 2020-03-26
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Changed
 ~~~~~~~
 
 * Make sure children and pipe can be set at the same time
+* ``SectionRenamed`` not raises error if old section name is not represented but the new one
 
 0.3.1_ - 2020-03-26
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,11 @@ Changed
 * Make sure children and pipe can be set at the same time
 * ``SectionRenamed`` not raises error if old section name is not represented but the new one
 
+Fixed
+~~~~~
+
+* Fixed a dictionary traversal issue regarding yaml file support
+
 0.3.1_ - 2020-03-26
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Changed
 ~~~~~~~
 
 * Make sure children and pipe can be set at the same time
+* Simplify yaml key rename logic
 * ``SectionRenamed`` not raises error if old section name is not represented but the new one
 * ``OptionRenamed`` not raises error if old option name is not represented but the new one
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Changed
 * Simplify yaml key rename logic
 * ``SectionRenamed`` not raises error if old section name is not represented but the new one
 * ``OptionRenamed`` not raises error if old option name is not represented but the new one
+* ``LineReplaced`` not raises error if old line is not represented but the new one
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ Fixed
 * Fixed a dictionary traversal issue regarding yaml file support
 * Fixed "Filed Rules" formatting of PR description by removing ``\xa0`` character
 * Fixed no Rule name in PR description if the Law did not change anything issue
+* Fixed an issue with ``LineReplaced``, if the input file is empty, raise an exception
 
 0.3.1_ - 2020-03-26
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,8 @@ Fixed
 ~~~~~
 
 * Fixed a dictionary traversal issue regarding yaml file support
+* Fixed "Filed Rules" formatting of PR description by removing ``\xa0`` character
+* Fixed no Rule name in PR description if the Law did not change anything issue
 
 0.3.1_ - 2020-03-26
 -------------------

--- a/hammurabi/mixins.py
+++ b/hammurabi/mixins.py
@@ -232,7 +232,13 @@ class PullRequestHelperMixin:  # pylint: disable=too-few-public-methods
         Return only those laws which has rules which made modifications.
         """
 
-        return filter(lambda l: [r for r in l.rules if r.made_changes], pillar.laws)
+        def filter_rules(law):
+            rules = list()
+            rules.extend([r for r in law.rules if r.made_changes])
+            rules.extend(law.failed_rules)
+            return rules
+
+        return filter(filter_rules, pillar.laws)
 
     def generate_pull_request_body(self, pillar) -> str:
         """

--- a/hammurabi/mixins.py
+++ b/hammurabi/mixins.py
@@ -6,7 +6,7 @@ extensions for several online git based VCS.
 
 import logging
 from pathlib import Path
-from typing import Iterable, List, Union
+from typing import Any, Iterable, List, Union
 
 from github3.repos.repo import Repository  # type: ignore
 
@@ -226,6 +226,14 @@ class PullRequestHelperMixin:  # pylint: disable=too-few-public-methods
 
         return body
 
+    @staticmethod
+    def __filter_laws_with_modifications(pillar) -> Iterable[Any]:
+        """
+        Return only those laws which has rules which made modifications.
+        """
+
+        return filter(lambda l: [r for r in l.rules if r.made_changes], pillar.laws)
+
     def generate_pull_request_body(self, pillar) -> str:
         """
         Generate the body of the pull request based on the registered laws and rules.
@@ -248,10 +256,7 @@ class PullRequestHelperMixin:  # pylint: disable=too-few-public-methods
             "Below you can find the executed laws and information about them.",
         ]
 
-        for law in pillar.laws:
-            if not [rule for rule in law.rules if rule.made_changes]:
-                continue
-
+        for law in self.__filter_laws_with_modifications(pillar):
             body.append(f"\n### {law.name}")
             body.append(law.description)
 

--- a/hammurabi/mixins.py
+++ b/hammurabi/mixins.py
@@ -179,6 +179,53 @@ class PullRequestHelperMixin:  # pylint: disable=too-few-public-methods
 
         return body
 
+    def __get_passed_rules(self, law) -> List[str]:
+        """
+        Get the passed rules for law if there is any.
+
+        :param law: Target Law which will be checked
+        :type law: Law
+
+        :return: Body of the PR section in a list format
+        :rtype: List[str]
+        """
+
+        #  NOTE: The parameter type can not be hinted, because of circular import,
+        #  we must fix this in the future releases.
+
+        body: List[str] = list()
+
+        has_passing_rules = len(law.failed_rules) != len(law.rules)
+        rules_with_changes = [rule for rule in law.rules if rule.made_changes]
+
+        if has_passing_rules and rules_with_changes:
+            body.append("\n#### Passed rules")
+            body.extend(self.__get_rules_body(rules_with_changes))
+
+        return body
+
+    def __get_failed_rules(self, law) -> List[str]:
+        """
+        Get the failed rules for law if there is any.
+
+        :param law: Target Law which will be checked
+        :type law: Law
+
+        :return: Body of the PR section in a list format
+        :rtype: List[str]
+        """
+
+        #  NOTE: The parameter type can not be hinted, because of circular import,
+        #  we must fix this in the future releases.
+
+        body: List[str] = list()
+
+        if law.failed_rules:
+            body.append("\n#### Failed rules (manual fix needed)")
+            body.extend(self.__get_rules_body(law.failed_rules))
+
+        return body
+
     def generate_pull_request_body(self, pillar) -> str:
         """
         Generate the body of the pull request based on the registered laws and rules.
@@ -202,22 +249,14 @@ class PullRequestHelperMixin:  # pylint: disable=too-few-public-methods
         ]
 
         for law in pillar.laws:
-            has_passing_rules = len(law.failed_rules) != len(law.rules)
-            rules_with_changes = [rule for rule in law.rules if rule.made_changes]
-
-            if not rules_with_changes:
+            if not [rule for rule in law.rules if rule.made_changes]:
                 continue
 
             body.append(f"\n### {law.name}")
             body.append(law.description)
 
-            if has_passing_rules and rules_with_changes:
-                body.append("\n#### Passed rules")
-                body.extend(self.__get_rules_body(rules_with_changes))
-
-            if law.failed_rules:
-                body.append("\n#### Failed rules (manual fix needed)")
-                body.extend(self.__get_rules_body(law.failed_rules))
+            body.extend(self.__get_passed_rules(law))
+            body.extend(self.__get_failed_rules(law))
 
         return "\n".join(body)
 

--- a/hammurabi/mixins.py
+++ b/hammurabi/mixins.py
@@ -202,16 +202,21 @@ class PullRequestHelperMixin:  # pylint: disable=too-few-public-methods
         ]
 
         for law in pillar.laws:
+            has_passing_rules = len(law.failed_rules) != len(law.rules)
+            rules_with_changes = [rule for rule in law.rules if rule.made_changes]
+
+            if not rules_with_changes:
+                continue
+
             body.append(f"\n### {law.name}")
             body.append(law.description)
 
-            body.append("\n#### Passed rules")
-            body.extend(
-                self.__get_rules_body([rule for rule in law.rules if rule.made_changes])
-            )
+            if has_passing_rules and rules_with_changes:
+                body.append("\n#### Passed rules")
+                body.extend(self.__get_rules_body(rules_with_changes))
 
             if law.failed_rules:
-                body.append("\n#### Failed rules (manual fix is needed)")
+                body.append("\n#### Failed rules (manual fix needed)")
                 body.extend(self.__get_rules_body(law.failed_rules))
 
         return "\n".join(body)

--- a/hammurabi/rules/base.py
+++ b/hammurabi/rules/base.py
@@ -85,9 +85,6 @@ class Rule(AbstractRule, ABC):
         self.children = children
         self.preconditions = preconditions
 
-        if self.pipe and self.children:
-            raise ValueError("pipe and children cannot be set at the same time")
-
         super().__init__(name, param)
 
     @property

--- a/hammurabi/rules/ini.py
+++ b/hammurabi/rules/ini.py
@@ -470,7 +470,8 @@ class OptionRenamed(SingleConfigFileRule):
         The execution must be stopped at this point, because if dependant rules
         will fail otherwise.
 
-        :raises: ``LookupError`` raised if no section can be renamed
+        :raises: ``LookupError`` raised if no section found or both the old and new
+                 option names are found
         :return: Return the input path as an output
         :rtype: Path
         """
@@ -478,8 +479,17 @@ class OptionRenamed(SingleConfigFileRule):
         if not self.updater.has_section(self.section):
             raise LookupError(f'No matching section for "{self.section}"')
 
-        if not self.updater.has_option(self.section, self.option):
-            raise LookupError(f'No matching option for "{self.option}"')
+        has_old_option = self.updater[self.section].get(self.option)
+        has_new_option = self.updater[self.section].get(self.new_name)
+
+        if has_old_option and has_new_option:
+            raise LookupError(f'Both "{self.option}" and "{self.new_name}" set')
+
+        if has_new_option:
+            return self.param
+
+        if not has_old_option:
+            raise LookupError(f'No matching option for "{self.section}"')
 
         logging.debug(
             'Replacing option "%s" with "%s"', str(self.option), self.new_name

--- a/hammurabi/rules/ini.py
+++ b/hammurabi/rules/ini.py
@@ -254,8 +254,7 @@ class SectionRenamed(SingleConfigFileRule):
         this point, because if other rules depending on the rename they will fail
         otherwise.
 
-        :raises: ``LookupError`` raised if no section can be renamed or both the
-                 new and old sections are in the config file
+        :raises: ``LookupError`` if we can not decide or can not find what should be renamed
         :return: Return the input path as an output
         :rtype: Path
         """

--- a/hammurabi/rules/ini.py
+++ b/hammurabi/rules/ini.py
@@ -263,14 +263,14 @@ class SectionRenamed(SingleConfigFileRule):
         has_old_section = self.updater.has_section(self.section)
         has_new_section = self.updater.has_section(self.new_name)
 
-        if not has_old_section:
-            raise LookupError(f'No matching section for "{self.section}"')
-
         if has_old_section and has_new_section:
             raise LookupError(f'Both "{self.section}" and "{self.new_name}" set')
 
         if has_new_section:
             return self.param
+
+        if not has_old_section:
+            raise LookupError(f'No matching section for "{self.section}"')
 
         logging.debug('Renaming "%s" to "%s"', self.section, self.new_name)
         self.updater[self.section].name = self.new_name

--- a/hammurabi/rules/mixins.py
+++ b/hammurabi/rules/mixins.py
@@ -22,12 +22,9 @@ class SelectorMixin:  # pylint: disable=too-few-public-methods
         """
 
         if isinstance(key_path, str):
-            if key_path.startswith("."):
-                key_path = key_path[1:]
-
             key_path = key_path.split(".")
 
-        return key_path
+        return list(filter(lambda key: key, key_path))
 
     def _get_by_selector(
         self, data: Any, key_path: Union[str, List[str]]
@@ -48,6 +45,11 @@ class SelectorMixin:  # pylint: disable=too-few-public-methods
 
         key_path = self.__normalize_key_path(key_path)
 
+        # Traversed and no remaining key
+        if not isinstance(data, dict) and not key_path:
+            return data
+
+        # Traversed or no remaining key
         if not data or not key_path:
             return None
 

--- a/hammurabi/rules/text.py
+++ b/hammurabi/rules/text.py
@@ -310,9 +310,16 @@ class LineReplaced(SinglePathRule):
         """
 
         target_match = list(filter(self.target.match, lines))
+        text = list(filter(lambda l: l.strip() == self.text, lines))
 
-        if not any(target_match):
-            raise LookupError(f'No matching line for "{self.target}"')
+        if target_match and text:
+            raise LookupError(f'Both "{str(self.target)}" and "{self.text}" exists')
+
+        if text:
+            return []
+
+        if not target_match:
+            raise LookupError(f'No matching line for "{str(self.target)}"')
 
         return target_match
 

--- a/hammurabi/rules/text.py
+++ b/hammurabi/rules/text.py
@@ -303,7 +303,8 @@ class LineReplaced(SinglePathRule):
         :param lines: Content of the given file
         :type lines: List[str]
 
-        :raises: ``LookupError``
+        :raises: ``LookupError`` if both ``target_match`` and ``text`` are set
+                 or nothing can be renamed
 
         :return: List of the matching line
         :rtype: List[str]

--- a/hammurabi/rules/yaml.py
+++ b/hammurabi/rules/yaml.py
@@ -30,7 +30,7 @@ class SingleDocumentYAMLFileRule(SinglePathRule, SelectorMixin):
         self.yaml.default_flow_style = False
 
         self.selector = self.validate(key, required=True)
-        self.split_key = self.selector.split('.')
+        self.split_key = self.selector.split(".")
         self.key_name: str = self.split_key[-1]
         self.loaded_yaml = Union[Dict[Hashable, Any], List[Any], None]
 
@@ -46,9 +46,8 @@ class SingleDocumentYAMLFileRule(SinglePathRule, SelectorMixin):
 
         # Get the parent for modifications. If there is no parent,
         # then the parent is the document root
-        return (
-            self._get_by_selector(self.loaded_yaml, self.split_key[:-1]) or self.loaded_yaml or {}
-        )
+        parent = self._get_by_selector(self.loaded_yaml, self.split_key[:-1])
+        return parent or self.loaded_yaml or {}
 
     def _write_dump(self, data: Any, delete: bool = False) -> None:
         """
@@ -61,7 +60,9 @@ class SingleDocumentYAMLFileRule(SinglePathRule, SelectorMixin):
         :type delete: bool
         """
 
-        updated_data = self._set_by_selector(self.loaded_yaml, self.split_key, data, delete)
+        updated_data = self._set_by_selector(
+            self.loaded_yaml, self.split_key, data, delete
+        )
         self.yaml.dump(updated_data, self.param)
 
     def pre_task_hook(self) -> None:

--- a/hammurabi/rules/yaml.py
+++ b/hammurabi/rules/yaml.py
@@ -248,14 +248,14 @@ class YAMLKeyRenamed(SingleDocumentYAMLFileRule):
         has_old_key = self.key_name in parent
         has_new_key = self.new_name in parent
 
-        if not has_old_key and not has_new_key:
-            raise LookupError(f'No matching key for "{self.selector}"')
-
         if has_old_key and has_new_key:
             raise LookupError(f'Both "{self.key_name}" and "{self.new_name}" set')
 
         if has_new_key:
             return self.param
+
+        if not has_old_key:
+            raise LookupError(f'No matching key for "{self.selector}"')
 
         parent[self.new_name] = deepcopy(parent[self.key_name])
         parent.pop(self.key_name)

--- a/tests/integration_tests/rules/test_yaml.py
+++ b/tests/integration_tests/rules/test_yaml.py
@@ -268,6 +268,24 @@ def test_value_exists_no_key(temporary_file):
 
 
 @pytest.mark.integration
+def test_value_exists_no_value(temporary_file):
+    expected_file = Path(temporary_file.name)
+    expected_file.write_text("stack: scala")
+
+    rule = YAMLValueExists(
+        name="Ensure service descriptor has dependencies",
+        path=expected_file,
+        key="stack",
+    )
+
+    rule.pre_task_hook()
+    rule.task()
+
+    assert expected_file.read_text() == "stack:\n"
+    expected_file.unlink()
+
+
+@pytest.mark.integration
 def test_value_exists_list(temporary_file):
     expected_file = Path(temporary_file.name)
     expected_file.write_text("stack: python\ndependencies: []")
@@ -291,6 +309,26 @@ def test_value_exists_list(temporary_file):
 
 
 @pytest.mark.integration
+def test_value_exists_list_single_item(temporary_file):
+    expected_file = Path(temporary_file.name)
+    expected_file.write_text("stack: python\ndependencies: []")
+
+    rule = YAMLValueExists(
+        name="Ensure service descriptor has dependencies",
+        path=expected_file,
+        key="dependencies",
+        value="service1",
+    )
+
+    rule.pre_task_hook()
+    rule.task()
+
+    # Because of the default flow style False, the result will be block-styled
+    assert expected_file.read_text() == "stack: python\ndependencies:\n- service1\n"
+    expected_file.unlink()
+
+
+@pytest.mark.integration
 def test_value_exists_list_already_exists(temporary_file):
     expected_file = Path(temporary_file.name)
     expected_file.write_text("stack: python\ndependencies: [service3]")
@@ -308,6 +346,28 @@ def test_value_exists_list_already_exists(temporary_file):
     assert (
         expected_file.read_text()
         == "stack: python\ndependencies: [service3, service1, service2]\n"
+    )
+    expected_file.unlink()
+
+
+@pytest.mark.integration
+def test_value_exists_list_already_exists_single_item(temporary_file):
+    expected_file = Path(temporary_file.name)
+    expected_file.write_text("stack: python\ndependencies: [service2]")
+
+    rule = YAMLValueExists(
+        name="Ensure service descriptor has dependencies",
+        path=expected_file,
+        key="dependencies",
+        value="service1",
+    )
+
+    rule.pre_task_hook()
+    rule.task()
+
+    assert (
+        expected_file.read_text()
+        == "stack: python\ndependencies: [service2, service1]\n"
     )
     expected_file.unlink()
 

--- a/tests/rules/test_rule.py
+++ b/tests/rules/test_rule.py
@@ -118,21 +118,6 @@ def test_cannot_proceed_precondition(mocked_config):
     assert not rule.post_task_hook.called
 
 
-def test_cannot_proceed_pipe_and_children():
-    piped_rule = ExampleRule(name="Test", param=None)
-    piped_rule.execute = Mock()
-
-    child_rule = ExampleRule(name="Test", param=None)
-    child_rule.execute = Mock()
-
-    with pytest.raises(ValueError) as exc:
-        ExampleRule(name="Test", param="Rule", pipe=piped_rule, children=[child_rule])
-
-    assert str(exc.value) == "pipe and children cannot be set at the same time"
-    assert not piped_rule.execute.called
-    assert not child_rule.execute.called
-
-
 @patch("hammurabi.rules.base.config")
 def test_execute_pipe(mocked_config):
     mocked_config.settings.dry_run = False

--- a/tests/rules/test_text.py
+++ b/tests/rules/test_text.py
@@ -250,7 +250,8 @@ def test_line_replaced_empty_file():
         path=expected_path, text=replacement, lines=[]
     )
 
-    rule.task()
+    with pytest.raises(LookupError):
+        rule.task()
 
     assert mock_file.writelines.called is False
 
@@ -277,8 +278,7 @@ def test_line_replaced_no_match_but_text():
 
     result = rule.task()
 
-    write_args = list(mock_file.writelines.call_args[0][0])
-    assert write_args == ["no\n", "match\n", f"{replacement}\n"]
+    assert mock_file.writelines.called is False
     assert result == expected_path
 
 

--- a/tests/rules/test_text.py
+++ b/tests/rules/test_text.py
@@ -272,9 +272,7 @@ def test_line_replaced_no_match_but_text():
     replacement = "apple tree"
 
     rule, mock_file = get_line_replaced_rule(
-        path=expected_path,
-        lines=["no", "match", replacement],
-        text=replacement
+        path=expected_path, lines=["no", "match", replacement], text=replacement
     )
 
     result = rule.task()
@@ -288,9 +286,7 @@ def test_line_replaced_no_match_no_text():
     expected_path = Mock()
 
     rule, mock_file = get_line_replaced_rule(
-        path=expected_path,
-        lines=["no", "match"],
-        text="apple tree"
+        path=expected_path, lines=["no", "match"], text="apple tree"
     )
 
     with pytest.raises(LookupError) as exc:
@@ -306,10 +302,7 @@ def test_line_replaced_both_target_and_text():
     text = "apple tree"
 
     rule, mock_file = get_line_replaced_rule(
-        path=expected_path,
-        lines=["no", target, text],
-        target=target,
-        text=text
+        path=expected_path, lines=["no", target, text], target=target, text=text
     )
 
     with pytest.raises(LookupError) as exc:

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -286,9 +286,7 @@ def test_generate_pull_request_body_no_changes_no_passing_law():
     failing_rule.made_changes = False
 
     law_3 = Law(
-        name="Test law 3",
-        description="Test description 3",
-        rules=[failing_rule],
+        name="Test law 3", description="Test description 3", rules=[failing_rule]
     )
 
     law_3.rules[0].made_changes = True

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -289,7 +289,7 @@ def test_generate_pull_request_body_no_changes_no_passing_law():
         name="Test law 3", description="Test description 3", rules=[failing_rule]
     )
 
-    law_3.rules[0].made_changes = True
+    law_3.rules[0].made_changes = False
     law_3.failed_rules = [failing_rule]
 
     mocked_pillar = Mock()

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -229,16 +229,101 @@ Test description 3
     assert body == expected_body
 
 
-def test_generate_pull_request_body_with_failed_rules():
-    failed_execution_law = Law(
+# https://github.com/gabor-boros/hammurabi/issues/14
+def test_generate_pull_request_body_no_changes_no_law():
+    failing_rule = ExampleRule(name="Test failed rule 1", param=Mock())
+    failing_rule.made_changes = False
+
+    law_1 = Law(
         name="Test law 1",
         description="Test description 1",
         rules=[ExampleRule(name="Test rule 1", param=Mock())],
     )
 
-    failed_execution_law.failed_rules = [
-        ExampleRule(name="Test failed rule 1", param=Mock())
-    ]
+    law_2 = Law(
+        name="Test law 2",
+        description="Test description 2",
+        rules=[ExampleRule(name="Test rule 2", param=Mock())],
+    )
+
+    law_3 = Law(
+        name="Test law 3",
+        description="Test description 3",
+        rules=[ExampleRule(name="Test rule 3", param=Mock()), failing_rule],
+    )
+
+    law_1.rules[0].made_changes = False
+    law_2.rules[0].made_changes = False
+
+    law_3.rules[0].made_changes = True
+    law_3.failed_rules = [failing_rule]
+
+    mocked_pillar = Mock()
+    mocked_pillar.laws = [law_1, law_2, law_3]
+
+    expected_body = """## Description
+Below you can find the executed laws and information about them.
+
+### Test law 3
+Test description 3
+
+#### Passed rules
+* Test rule 3
+
+#### Failed rules (manual fix needed)
+* Test failed rule 1"""
+
+    pr_helper = get_pull_request_helper_mixin_consumer()
+
+    body = pr_helper.generate_pull_request_body(mocked_pillar)
+
+    assert body == expected_body
+
+
+# https://github.com/gabor-boros/hammurabi/issues/14
+def test_generate_pull_request_body_no_changes_no_passing_law():
+    failing_rule = ExampleRule(name="Test failed rule 1", param=Mock())
+    failing_rule.made_changes = False
+
+    law_3 = Law(
+        name="Test law 3",
+        description="Test description 3",
+        rules=[failing_rule],
+    )
+
+    law_3.rules[0].made_changes = True
+    law_3.failed_rules = [failing_rule]
+
+    mocked_pillar = Mock()
+    mocked_pillar.laws = [law_3]
+
+    expected_body = """## Description
+Below you can find the executed laws and information about them.
+
+### Test law 3
+Test description 3
+
+#### Failed rules (manual fix needed)
+* Test failed rule 1"""
+
+    pr_helper = get_pull_request_helper_mixin_consumer()
+
+    body = pr_helper.generate_pull_request_body(mocked_pillar)
+
+    assert body == expected_body
+
+
+def test_generate_pull_request_body_with_failed_rules():
+    failed_rule = ExampleRule(name="Test failed rule 1", param=Mock())
+    failed_rule.made_changes = False
+
+    failed_execution_law = Law(
+        name="Test law 1",
+        description="Test description 1",
+        rules=[ExampleRule(name="Test rule 1", param=Mock()), failed_rule],
+    )
+
+    failed_execution_law.failed_rules = [failed_rule]
 
     mocked_pillar = Mock()
     mocked_pillar.laws = [
@@ -267,7 +352,7 @@ Test description 1
 #### Passed rules
 * Test rule 1
 
-#### Failed rules (manual fix is needed)
+#### Failed rules (manual fix needed)
 * Test failed rule 1
 
 ### Test law 2
@@ -291,27 +376,29 @@ Test description 3
 
 
 def test_generate_pull_request_body_with_chained_rules():
+    failed_rule = ExampleRule(
+        name="Test failed rule 1",
+        param=Mock(),
+        preconditions=[PASSING_PRECONDITION],
+        children=[get_passing_rule("Child rule")],
+    )
+
+    failed_rule.made_changes = False
+
+    passing_rule = ExampleRule(
+        name="Test rule 1",
+        param=Mock(),
+        preconditions=[PASSING_PRECONDITION],
+        children=[get_passing_rule("Passing child rule")],
+    )
+
     failed_execution_law = Law(
         name="Test law 1",
         description="Test description 1",
-        rules=[
-            ExampleRule(
-                name="Test rule 1",
-                param=Mock(),
-                preconditions=[PASSING_PRECONDITION],
-                children=[get_passing_rule("Passing child rule")],
-            )
-        ],
+        rules=[passing_rule, failed_rule],
     )
 
-    failed_execution_law.failed_rules = [
-        ExampleRule(
-            name="Test failed rule 1",
-            param=Mock(),
-            preconditions=[PASSING_PRECONDITION],
-            children=[get_passing_rule("Child rule")],
-        )
-    ]
+    failed_execution_law.failed_rules = [failed_rule]
 
     mocked_pillar = Mock()
     mocked_pillar.laws = [
@@ -341,7 +428,7 @@ Test description 1
 * Test rule 1
 ** Passing child rule
 
-#### Failed rules (manual fix is needed)
+#### Failed rules (manual fix needed)
 * Test failed rule 1
 ** Child rule
 


### PR DESCRIPTION
**Reason for the change**

* Resolves #14  
* Resolves #38 

**Description**

* Simplify yaml key rename logic
* ``SectionRenamed`` not raises error if old section name is not represented but the new one
* ``OptionRenamed`` not raises error if old option name is not represented but the new one
* ``LineReplaced`` not raises error if old line is not represented but the new one
* Fixed a dictionary traversal issue regarding yaml file support
* Fixed "Filed Rules" formatting of PR description by removing ``\xa0`` character
* Fixed no Rule name in PR description if the Law did not change anything issue
* Fixed empty passed rules shown in PR description issue

**Code examples**

N/A

**Checklist**

- [x] Unit tests created/updated
- [x] Documentation extended/updated

**References**

N/A
