### PR TITLE
Finetune execution for 0.4.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,7 @@ Fixed
 * Fixed a dictionary traversal issue regarding yaml file support
 * Fixed "Failed Rules" formatting of PR description by removing ``\xa0`` character
 * Fixed no Rule name in PR description if the Law did not change anything issue
+* Fixed nested rule indentation PR description markup
 * Fixed an issue with ``LineReplaced``, if the input file is empty, raise an exception
 
 0.3.1_ - 2020-03-26

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,7 +49,7 @@ Fixed
 ~~~~~
 
 * Fixed a dictionary traversal issue regarding yaml file support
-* Fixed "Filed Rules" formatting of PR description by removing ``\xa0`` character
+* Fixed "Failed Rules" formatting of PR description by removing ``\xa0`` character
 * Fixed no Rule name in PR description if the Law did not change anything issue
 * Fixed an issue with ``LineReplaced``, if the input file is empty, raise an exception
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,7 @@ Changed
 * "No changes made by" messages now info logs instead of warnings
 * Commit changes only if the Law has passing rules
 * If ``PreconditionFailedError`` raised, do not log error messages, log a warning instead
+* ``LineExists`` will not raise an exception if multiple targets found, instead it will select the last match as target
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Added
 
 * Added ``Reporter`` and ``JSONReporter`` classes to be able to expose execution results
 * Add new config option ``report_name`` to the available settings
+* New exception type ``PreconditionFailedError`` indicating that the precondition failed and no need to raise an error
 
 Changed
 ~~~~~~~
@@ -40,6 +41,9 @@ Changed
 * Pillar prepare its Reporter for report generation
 * Pillar has a new argument to set the pillar's reporter easily
 * CLI's enforce command now calls the Pillar's prepared Reporter to do the report
+* "No changes made by" messages now info logs instead of warnings
+* Commit changes only if the Law has passing rules
+* If ``PreconditionFailedError`` raised, do not log error messages, log a warning instead
 
 Fixed
 ~~~~~

--- a/hammurabi/exceptions.py
+++ b/hammurabi/exceptions.py
@@ -3,3 +3,12 @@ class AbortLawError(Exception):
     Custom exception to make sure that own exception types are
     caught by the Law's execution.
     """
+
+
+class PreconditionFailedError(Exception):
+    """
+    Custom exception representing a failed precondition. In case a
+    precondition failed, there is no need to raise an error and report
+    the rule as a failure. The precondition is for checking that a rule
+    should or shouldn't run; not for breaking the execution.
+    """

--- a/hammurabi/mixins.py
+++ b/hammurabi/mixins.py
@@ -177,7 +177,7 @@ class PullRequestHelperMixin:  # pylint: disable=too-few-public-methods
             body.append(f"* {rule.name}")
 
             for chain in self.__get_chained_rules(rule, rule.get_rule_chain(rule)):
-                body.append(f"** {chain.name}")
+                body.append(f"  * {chain.name}")
 
         return body
 

--- a/hammurabi/preconditions/base.py
+++ b/hammurabi/preconditions/base.py
@@ -1,12 +1,14 @@
 """
-This module contains the definition of Rule which describes what to do with
-the received parameter and does the necessary changes.
+This module contains the definition of Preconditions which describes what to do with
+the received parameter and does the necessary changes. The preconditions are used to
+enable developers skipping or enabling rules based on a set of conditions.
 
-The Rule is an abstract class which describes all the required methods and
-parameters, but it can be extended and customized easily by inheriting from
-it. A good example for this kind of customization is :class:`hammurabi.rules.text.LineExists`
-which adds more parameters to :class:`hammurabi.rules.files.SingleFileRule` which
-inherits from :class:`hammurabi.rules.base.Rule`.
+.. warning::
+
+    The precondition is for checking that a rule should or shouldn't run, not for
+    breaking/aborting the execution. To indicate a precondition failure as an error
+    in the logs, create a precondition which raises an exception if the requirements
+    doesn't match.
 """
 
 from __future__ import annotations

--- a/hammurabi/rules/base.py
+++ b/hammurabi/rules/base.py
@@ -16,6 +16,7 @@ import logging
 from typing import Any, Iterable, List, Optional, Union
 
 from hammurabi.config import config
+from hammurabi.exceptions import PreconditionFailedError
 from hammurabi.preconditions.base import Precondition
 from hammurabi.rules.abstract import AbstractRule
 
@@ -197,11 +198,10 @@ class Rule(AbstractRule, ABC):
         self.param = param or self.param
 
         if not self.can_proceed:
-            logging.warning(
-                'Skipping execution of "%s", the prerequisites are not fulfilled',
-                self.name,
-            )
-            raise AssertionError(f'"{self.name}" cannot proceed')
+            if config.settings.dry_run:
+                raise AssertionError(f'"{self.name}" cannot proceed because of dry run')
+
+            raise PreconditionFailedError(f'"{self.name}" cannot proceed')
 
         logging.debug('Running pre task hook for "%s"', self.name)
         self.pre_task_hook()

--- a/hammurabi/rules/mixins.py
+++ b/hammurabi/rules/mixins.py
@@ -28,7 +28,7 @@ class SelectorMixin:  # pylint: disable=too-few-public-methods
 
     def _get_by_selector(
         self, data: Any, key_path: Union[str, List[str]]
-    ) -> Union[None, Any]:
+    ) -> Dict[str, Any]:
         """
         Get a key's value by a selector and traverse the path.
 
@@ -43,20 +43,18 @@ class SelectorMixin:  # pylint: disable=too-few-public-methods
         :rtype: :class:``hammurabi.rules.mixins.Any`
         """
 
+        if not data:
+            return dict()
+
         key_path = self.__normalize_key_path(key_path)
+        entry = data or dict()
 
-        # Traversed and no remaining key
-        if not isinstance(data, dict) and not key_path:
-            return data
+        for item in key_path:
+            entry = entry.get(item, None)
+            if not entry:
+                return dict()
 
-        # Traversed or no remaining key
-        if not data or not key_path:
-            return None
-
-        key = key_path.pop()
-        remaining_data = data.get(key, None)
-
-        return self._get_by_selector(remaining_data, key_path)
+        return entry
 
     def _set_by_selector(
         self,

--- a/hammurabi/rules/text.py
+++ b/hammurabi/rules/text.py
@@ -87,7 +87,7 @@ class LineExists(SinglePathRule):
         :param lines: Content of the given file
         :type lines: List[str]
 
-        :raises: ``LookupError``
+        :raises: ``LookupError`` if no matching line can be found for target
 
         :return: List of the matching line
         :rtype: str
@@ -95,11 +95,8 @@ class LineExists(SinglePathRule):
 
         target_match = list(filter(self.target.match, lines))
 
-        if not any(target_match):
+        if not target_match:
             raise LookupError(f'No matching line for "{self.target}"')
-
-        if len(target_match) > 1:
-            raise LookupError(f'Multiple matching lines for "{self.target}"')
 
         return target_match.pop()
 
@@ -155,7 +152,9 @@ class LineExists(SinglePathRule):
 
         if not file_was_empty and no_criteria_match:
             target_match = self.__get_target_match(lines)
-            target_match_index = lines.index(target_match)
+
+            # Get the index of the element from the right
+            target_match_index = len(lines) - lines[::-1].index(target_match) - 1
 
             insert_position = target_match_index + self.position
 

--- a/hammurabi/rules/yaml.py
+++ b/hammurabi/rules/yaml.py
@@ -36,7 +36,7 @@ class SingleDocumentYAMLFileRule(SinglePathRule, SelectorMixin):
 
         super().__init__(name, path, **kwargs)
 
-    def _get_parent(self) -> Any:
+    def _get_parent(self) -> Dict[str, Any]:
         """
         Get the parent of the given key by its selector.
 
@@ -46,8 +46,7 @@ class SingleDocumentYAMLFileRule(SinglePathRule, SelectorMixin):
 
         # Get the parent for modifications. If there is no parent,
         # then the parent is the document root
-        parent = self._get_by_selector(self.loaded_yaml, self.split_key[:-1])
-        return parent or self.loaded_yaml or {}
+        return self._get_by_selector(self.loaded_yaml, self.split_key[:-1])
 
     def _write_dump(self, data: Any, delete: bool = False) -> None:
         """
@@ -366,12 +365,9 @@ class YAMLValueExists(SingleDocumentYAMLFileRule):
 
         parent = self._get_parent()
 
-        if self.key_name not in parent:
-            raise LookupError(f'No matching key for selector "{self.selector}"')
-
         if self.value is None:
             parent[self.key_name] = self.value
-        if isinstance(parent.get(self.key_name), list):
+        elif isinstance(parent.get(self.key_name), list):
             if isinstance(self.value, list):
                 parent[self.key_name].extend(self.value)
             else:

--- a/tests/rules/test_rule.py
+++ b/tests/rules/test_rule.py
@@ -6,6 +6,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 import pytest
 
+from hammurabi.exceptions import PreconditionFailedError
 from tests.helpers import FAILING_PRECONDITION, PASSING_PRECONDITION, ExampleRule
 
 
@@ -89,7 +90,7 @@ def test_cannot_proceed_dry_run(config):
     with pytest.raises(AssertionError) as exc:
         rule.execute("Rule")
 
-    assert str(exc.value) == '"Test" cannot proceed'
+    assert str(exc.value) == '"Test" cannot proceed because of dry run'
     assert not rule.pre_task_hook.called
     assert not rule.post_task_hook.called
 
@@ -110,7 +111,7 @@ def test_cannot_proceed_precondition(mocked_config):
     rule.pre_task_hook = Mock()
     rule.post_task_hook = Mock()
 
-    with pytest.raises(AssertionError) as exc:
+    with pytest.raises(PreconditionFailedError) as exc:
         rule.execute("Rule")
 
     assert str(exc.value) == '"Test" cannot proceed'

--- a/tests/rules/test_text.py
+++ b/tests/rules/test_text.py
@@ -138,11 +138,11 @@ def test_line_exists_multiple_matches():
         path=expected_path, target=target, lines=["target", "target_match"]
     )
 
-    with pytest.raises(LookupError) as exc:
-        rule.task()
+    result = rule.task()
 
-    assert str(exc.value).startswith("Multiple matching lines for")
-    assert mock_file.writelines.called is False
+    write_args = list(mock_file.writelines.call_args[0][0])
+    assert write_args == [f"{target}\n", "target_match\n", f"{rule.text}\n"]
+    assert result == expected_path
 
 
 def test_line_exists_failed_criteria():

--- a/tests/test_law.py
+++ b/tests/test_law.py
@@ -5,7 +5,12 @@ from hypothesis import strategies as st
 import pytest
 
 from hammurabi import Law
-from tests.helpers import ExampleRule, get_failing_rule, get_passing_rule, ExamplePrecondition
+from tests.helpers import (
+    ExamplePrecondition,
+    ExampleRule,
+    get_failing_rule,
+    get_passing_rule,
+)
 
 
 @given(name=st.text(), description=st.text())
@@ -73,9 +78,7 @@ def test_rule_execution_failed_precondition_no_abort(mocked_config, mocked_loggi
     rule = get_passing_rule()
     rule.made_changes = False
 
-    rule.preconditions = [
-        ExamplePrecondition(param=False)
-    ]
+    rule.preconditions = [ExamplePrecondition(param=False)]
 
     rule.param = expected_exception
     rule.get_rule_chain = Mock(return_value=[get_passing_rule()])

--- a/tests/test_law.py
+++ b/tests/test_law.py
@@ -5,7 +5,7 @@ from hypothesis import strategies as st
 import pytest
 
 from hammurabi import Law
-from tests.helpers import ExampleRule, get_failing_rule, get_passing_rule
+from tests.helpers import ExampleRule, get_failing_rule, get_passing_rule, ExamplePrecondition
 
 
 @given(name=st.text(), description=st.text())
@@ -46,22 +46,47 @@ def test_executes_task():
 def test_rule_execution_failed_no_abort(mocked_config, mocked_logging):
     mocked_config.settings.rule_can_abort = False
     mocked_logging.error = Mock()
-    mocked_logging.warning = Mock()
     expected_exception = "failed"
 
     rule = get_failing_rule()
+    rule.made_changes = False
     rule.param = expected_exception
     rule.get_rule_chain = Mock(return_value=[get_passing_rule()])
 
-    law = Law(name="Passing", description="passing law", rules=(rule,))
+    law = Law(name="Failing", description="failing law", rules=(rule,))
     law.commit = Mock()
 
     law.enforce()
 
     assert mocked_logging.error.called
     rule.get_rule_chain.assert_called_once_with(rule)
+    assert law.commit.called is False
+
+
+@patch("hammurabi.law.logging")
+@patch("hammurabi.law.config")
+def test_rule_execution_failed_precondition_no_abort(mocked_config, mocked_logging):
+    mocked_config.settings.rule_can_abort = False
+    mocked_logging.warning = Mock()
+    expected_exception = "failed"
+
+    rule = get_passing_rule()
+    rule.made_changes = False
+
+    rule.preconditions = [
+        ExamplePrecondition(param=False)
+    ]
+
+    rule.param = expected_exception
+    rule.get_rule_chain = Mock(return_value=[get_passing_rule()])
+
+    law = Law(name="Failing", description="failing law", rules=(rule,))
+    law.commit = Mock()
+
+    law.enforce()
+
     assert mocked_logging.warning.called
-    law.commit.assert_called_once_with()
+    assert law.commit.called is False
 
 
 @patch("hammurabi.rules.base.config")
@@ -71,7 +96,6 @@ def test_rule_execution_aborted(mocked_logging, law_config, base_rule_config):
     law_config.settings.rule_can_abort = True
     base_rule_config.settings.dry_run = False
     mocked_logging.error = Mock()
-    mocked_logging.warning = Mock()
     expected_exception = "failed"
 
     rule = get_failing_rule()
@@ -87,7 +111,6 @@ def test_rule_execution_aborted(mocked_logging, law_config, base_rule_config):
     assert mocked_logging.error.called
     assert str(exc.value) == expected_exception
     rule.get_rule_chain.assert_called_once_with(rule)
-    assert mocked_logging.warning.called
     assert law.commit.called is False
 
 
@@ -138,5 +161,4 @@ def test_commit_no_changes():
     law.enforce()
 
     rule.execute.assert_called_once_with()
-    law.get_execution_order.assert_called_once_with()
     assert law.git_commit.called is False

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -424,11 +424,11 @@ Test description 1
 
 #### Passed rules
 * Test rule 1
-** Passing child rule
+  * Passing child rule
 
 #### Failed rules (manual fix needed)
 * Test failed rule 1
-** Child rule
+  * Child rule
 
 ### Test law 2
 Test description 2


### PR DESCRIPTION
**Reason for the change**

The dictionary traversal is fishy and preconditions reporting errors instead of warning since they are part of the execution chain.

**Description**

* New exception type ``PreconditionFailedError`` indicating that the precondition failed and no need to raise an error
* "No changes made by" messages now info logs instead of warnings
* Commit changes only if the Law has passing rules
* If ``PreconditionFailedError`` raised, do not log error messages, log a warning instead
* ``LineExists`` will not raise an exception if multiple targets found, instead it will select the last match as target
* Fixed nested rule indentation PR description markup

Also, fixing a typo in the changelog.

**Code examples**

N/A

**Checklist**

- [x] Unit tests created/updated
- [x] Documentation extended/updated

**References**

N/A
