### PR TITLE
Reduce the complexity of ``DictValueExists`` and ``DictValueNotExists…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,7 @@ Changed
 * Unify log message styles
 * Adjust logging levels
 * Use dictionary parsed rules as a base for YAML and JSON rules
+* Reduced the complexity of ``DictValueExists`` and ``DictValueNotExists`` rules
 
 0.6.0_ - 2020-04-06
 -------------------


### PR DESCRIPTION
**Reason for the change**

Method complexity of ``task`` in ``DictValueExists`` and ``DictValueNotExists`` is high.

**Description**

Reduce the complexity of ``DictValueExists`` and ``DictValueNotExists`` rules.

**Code examples**

N/A

**Checklist**

~- [ ] Unit tests created/updated~
~- [ ] Documentation extended/updated~

**References**

resolves https://github.com/gabor-boros/hammurabi/issues/69
resolves https://github.com/gabor-boros/hammurabi/issues/68
