### PR TITLE
Remove criteria fileds

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,11 @@ Changed
 * Reduced the method complexity of ``LineExists`` task execution
 * Reduced the method complexity of ``SectionExists`` task execution
 
+Removed
+~~~~~~~
+
+* Remove ``criteria`` fields since Hammurabi now supports preconditions and it breaks the API uniformity
+
 0.6.0_ - 2020-04-06
 -------------------
 

--- a/tests/rules/test_text.py
+++ b/tests/rules/test_text.py
@@ -6,23 +6,13 @@ from hammurabi.rules.text import LineExists, LineNotExists, LineReplaced
 
 
 def get_line_exists_rule(
-    text="Example text",
-    criteria="Example criteria",
-    target="Example target",
-    position=1,
-    lines=[],
-    **kwargs,
+    text="Example text", target="Example target", position=1, lines=[], **kwargs
 ):
     mock_file = Mock()
     mock_file.read.return_value.splitlines.return_value = lines
 
     rule = LineExists(
-        name="Line exists rule",
-        text=text,
-        criteria=criteria,
-        target=target,
-        position=position,
-        **kwargs,
+        name="Line exists rule", text=text, target=target, position=position, **kwargs
     )
 
     rule.param.open.return_value.__enter__ = Mock(return_value=mock_file)
@@ -95,12 +85,11 @@ def test_line_exists_with_indentation():
 @patch("hammurabi.rules.text.re")
 def test_line_exists_re_compiled(mocked_re):
     expected_path = Mock()
-    criteria = "criteria"
     target = "target"
 
-    get_line_exists_rule(path=expected_path, criteria=criteria, target=target)
+    get_line_exists_rule(path=expected_path, target=target)
 
-    mocked_re.compile.assert_has_calls([call(criteria), call(target), call(r"^\s+")])
+    mocked_re.compile.assert_has_calls([call(target), call(r"^\s+")])
 
 
 def test_line_exists_empty_file():
@@ -143,19 +132,6 @@ def test_line_exists_multiple_matches():
     write_args = list(mock_file.writelines.call_args[0][0])
     assert write_args == [f"{target}\n", "target_match\n", f"{rule.text}\n"]
     assert result == expected_path
-
-
-def test_line_exists_failed_criteria():
-    expected_path = Mock()
-    criteria = "criteria"
-
-    rule, mock_file = get_line_exists_rule(
-        path=expected_path, criteria=criteria, lines=[criteria, "other line"]
-    )
-
-    rule.task()
-
-    assert mock_file.writelines.called is False
 
 
 def test_line_not_exists():


### PR DESCRIPTION
**Reason for the change**

Use preconditions instead of criteria parameters. That way the core will be lot cleaner, and the behaviour of the Rule will be more explicit.

**Description**

Remove ``criteria`` fields since Hammurabi now supports preconditions and it breaks the API uniformity

**Code examples**

```python
LineExists(
    name='Add X-Ray import to settings.py',
    path=Path("settings.py"),
    target=r'^from config import init_settings',
    text="import xray,
    preconditions=[
        HasStack(stacks=["python"]),
        IsFileNotContains(path=Path("settings.py"), criteria=rf'^import xray$')
    ]
)
```

**Checklist**

- [x] Unit tests created/updated
- [x] Documentation extended/updated

**References**

resolves https://github.com/gabor-boros/hammurabi/issues/47
