### PR TITLE
Fix recursive directory removal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,11 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 Unreleased_
 -----------
 
+Fixed
+~~~~~
+
+* Fix recursive directory removal issue
+
 0.7.0_ - 2020-04-28
 -------------------
 

--- a/hammurabi/mixins.py
+++ b/hammurabi/mixins.py
@@ -94,7 +94,7 @@ class GitMixin:
         if self.__can_proceed():
             logging.debug('Git remove "%s"', str(param))
             config.repo.index.remove(
-                (str(param),), ignore_unmatch=True
+                (str(param),), ignore_unmatch=True, r=True
             )  # pylint: disable=no-member
             self.made_changes = True
 

--- a/tests/rules/test_text.py
+++ b/tests/rules/test_text.py
@@ -63,7 +63,7 @@ def test_line_exists_no_newline():
         target="$",
         text=expected_text,
         lines=["some", "lines"],
-        ensure_trailing_newline=True
+        ensure_trailing_newline=True,
     )
 
     result = rule.task()

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -95,7 +95,7 @@ def test_git_remove(mocked_config):
     git_mixin.git_remove(expected_path)
 
     mocked_config.repo.index.remove.assert_called_once_with(
-        (str(expected_path),), ignore_unmatch=True
+        (str(expected_path),), ignore_unmatch=True, r=True
     )
 
 


### PR DESCRIPTION
**Reason for the change**

The directory removals are failing if the recursive removal flag is not set.

**Description**

Add recursive removal flag.

**Code examples**

n/a

**Checklist**

~- [ ] Unit tests created/updated~
~- [ ] Documentation extended/updated~

**References**

n/a
