### PR TITLE
GitHub API url is transformed to Pull Request URLs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,11 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 Unreleased_
 -----------
 
+Fixed
+~~~~~
+
+* GitHub API url is transformed to Pull Request URLs
+
 0.8.1_ - 2020-07-20
 -------------------
 

--- a/hammurabi/mixins.py
+++ b/hammurabi/mixins.py
@@ -258,6 +258,21 @@ class GitHubMixin(GitMixin, PullRequestHelperMixin):
         base_matching = pull_request.base.ref == config.settings.git_base_name
         return base_matching and head_matching
 
+    @staticmethod
+    def __get_pr_url(pr_api_url: str) -> str:
+        """
+        Get Pull Request id from the API url and return the UI version of that.
+
+        :param pr_api_url: Pull Request API URL
+        :type pr_api_url: str
+
+        :return: UI version of the Pull Request
+        :rtype: str
+        """
+
+        pull_request_id = pr_api_url.split("/")[-1]
+        return f"https://github.com/{config.settings.repository}/pull/{pull_request_id}"
+
     def create_pull_request(self) -> Optional[str]:
         """
         Create a PR on GitHub after the changes are pushed to remote. The pull
@@ -309,11 +324,11 @@ class GitHubMixin(GitMixin, PullRequestHelperMixin):
                     body=description,
                 )
 
-                return response.url
+                return self.__get_pr_url(response.url)
 
             # Return the last known PR url, it should be one
             # anyways, so it is not an issue
-            pull_request_url = opened_pull_request.url
+            pull_request_url = self.__get_pr_url(opened_pull_request.url)
             logging.info("Found open pull request %s", pull_request_url)
             return pull_request_url
 

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -608,12 +608,13 @@ def test_github_pull_request_has_opened_pr(mocked_config):
     expected_branch_name = "awesome branch"
     expected_owner = "gabor-boros"
     expected_repo_name = "hammurabi"
+    api_url = "https://api.github.com/repos/gabor-boros/hammurabi/pulls/1"
     expected_url = "https://github.com/gabor-boros/hammurabi/pull/1"
     mocked_repository = Mock()
     mocked_repository.pull_requests.return_value = iter(
         [
             Mock(
-                url=expected_url,
+                url=api_url,
                 base=Mock(ref=expected_base_name),
                 head=Mock(ref=expected_branch_name),
             )


### PR DESCRIPTION
**Reason for the change**

The GitHub API has been changed but the python package handling the API communication is not adjusted.

**Description**

Make sure that the API url returned by GitHub is transformed to non-API Pull Request URL.

**Code examples**

N/A

**Checklist**

- [x] Unit tests created/updated
~- [ ] Documentation extended/updated~

**References**

N/A
