### PR TITLE
Fix precondition validation attribute error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,11 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 Unreleased_
 -----------
 
+Fixed
+~~~~~
+
+* Fix MRO issue when precondition names cannot be retrieved when exception occurs
+
 0.11.0_ - 2020-09-19
 --------------------
 

--- a/hammurabi/rules/abstract.py
+++ b/hammurabi/rules/abstract.py
@@ -21,11 +21,11 @@ class AbstractRule(ABC):
     :type param: Any
     """
 
-    __slots__ = ("param", "name", "made_changes")
+    __slots__ = ("__name", "param", "made_changes")
 
     def __init__(self, name: str, param: Any) -> None:
         self.param = param
-        self.name = name.strip()
+        self.__name = name.strip()
 
         # Set by GitMixin or other mixins to indicate that the rule did changes.
         # Rules can set this flag directly too. Only those rules will be indicated on
@@ -76,6 +76,26 @@ class AbstractRule(ABC):
             return val
 
         return cast_to(val)
+
+    @property
+    def name(self) -> str:
+        """
+        Return the name of the :class:`hammurabi.rules.base.Rule`.
+
+        :return: The name of the given :class:`hammurabi.rules.base.Rule`
+        :rtype: str
+
+        .. note::
+
+            Name is defined as a separate property and not an attribute to
+            make sure we return a default value in those cases when we cannot
+            set the name due to an error.
+        """
+
+        try:
+            return self.__name
+        except AttributeError:
+            return f"{self.__class__.__name__}"
 
     @property
     def description(self) -> str:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -42,6 +42,20 @@ class ExampleGitHubMixinRule(ExampleRule, GitHubMixin):
     pass
 
 
+class ExampleMROFaultyPrecondition(Precondition):
+    """
+    This example precondition exists to ensure MRO related cases like
+    https://github.com/gabor-boros/hammurabi/issues/216 are tested.
+    """
+
+    def __init__(self, param=None) -> None:
+        stacks = self.validate(param, required=True)
+        super().__init__(None, stacks)
+
+    def task(self) -> bool:
+        return self.param
+
+
 PASSING_PRECONDITION = ExamplePrecondition(name="Passing", param=True)
 FAILING_PRECONDITION = ExamplePrecondition(name="Failing", param=False)
 

--- a/tests/rules/test_rule.py
+++ b/tests/rules/test_rule.py
@@ -7,7 +7,12 @@ from hypothesis import strategies as st
 import pytest
 
 from hammurabi.exceptions import PreconditionFailedError
-from tests.helpers import FAILING_PRECONDITION, PASSING_PRECONDITION, ExampleRule
+from tests.helpers import (
+    FAILING_PRECONDITION,
+    PASSING_PRECONDITION,
+    ExamplePrecondition,
+    ExampleRule,
+)
 
 
 def test_repr():
@@ -19,11 +24,27 @@ def test_repr():
     assert repr(eval(repr(rule))) == expected
 
 
+def test_precondition_repr_without_name():
+    expected = (
+        'ExamplePrecondition(name="ExamplePrecondition precondition", param="True")'
+    )
+    precondition = ExamplePrecondition(name=None, param=True)
+
+    assert repr(precondition) == expected
+    # The repr should be used with eval
+    assert repr(eval(repr(precondition))) == expected
+
+
 def test_str():
     expected = "Test rule"
     rule = ExampleRule(name="Test", param="Rule")
 
     assert str(rule) == expected
+
+
+def test_precondition_str_without_name():
+    precondition = ExamplePrecondition(name=None, param=True)
+    assert str(precondition) == "ExamplePrecondition precondition"
 
 
 @patch("hammurabi.rules.abstract.full_strip")


### PR DESCRIPTION
**Reason for the change**

https://github.com/gabor-boros/hammurabi/issues/216

**Description**

Fix `Precondition`'s parameter validation raises Attribute error because of wrong method resolution order, hence this error hides all the other errors which may occur on that call stack.

**Code examples**

See in the related issue.

**Checklist**

- [x] Unit tests created/updated
~- [ ] Documentation extended/updated~

**References**

Closes #216 
